### PR TITLE
hm-mod: monitors: replace keywordParams with monitorv2

### DIFF
--- a/examples/vertical-monitors.nix
+++ b/examples/vertical-monitors.nix
@@ -5,7 +5,7 @@
     with config.wayland.windowManager.hyprland.monitors; {
       # This display is always present, since it's built in to the laptop.
       laptop-internal = {
-        # Either `name` or `description` must be defined.
+        # Either `output` or `description` must be defined.
         #
         # You should probably prefer `description` because for most DRM output
         # nodes (for example `HDMI-A-1` or `DP-5`), hard-coded settings aren't
@@ -15,7 +15,7 @@
         # DRM node is consistent between reboots or re-connections.
         #
         # Since this display is built-in, in this specific circumstance,
-        # using `name = "eDP-1"` would also work fine.
+        # using `output = "eDP-1"` would also work fine.
         description = "Samsung Display Corp. 0x4193";
         resolution = {
           x = 2880;
@@ -66,7 +66,7 @@
       # Here is an entry that will handle arbitrary monitors,
       # setting the position to the right side of `laptop-internal`.
       default = {
-        name = "";
+        output = "";
         resolution = "preferred";
         position = lib.mapAttrs (_: builtins.floor) {
           x = laptop-internal.position.x + laptop-internal.size.x;

--- a/hm-module/config.nix
+++ b/hm-module/config.nix
@@ -155,6 +155,13 @@ in {
           [ "source" ]
 
           [ "monitor" ]
+          [ "monitorv2" ]
+          [ "monitorv2" "output" ]
+          [ "monitorv2" "mode" ]
+          [ "monitorv2" "position" ]
+          [ "monitorv2" "scale" ]
+          [ "monitorv2" "transform" ]
+
           [ "workspace" ]
 
           [ "dwindle" ]

--- a/hm-module/monitors.nix
+++ b/hm-module/monitors.nix
@@ -58,206 +58,205 @@ let
         };
       };
     };
+
+  monitorDefType = types.submodule ({ config, ... }: {
+    options = {
+      name = lib.mkOption {
+        type = types.singleLineStr;
+        description = ''
+          The name of the monitor as shown in the output of
+          `hyprctl monitors`, for example `eDP-1` or `HDMI-A-1`.
+        '';
+      };
+      description = lib.mkOption {
+        type = types.nullOr types.singleLineStr;
+        default = null;
+        description = ''
+          The description of a monitor as shown in the output of
+          `hyprctl monitors` (without the parenthesized name at the end).
+        '';
+      };
+      position = lib.mkOption {
+        type = types.either (point2DType types.ints.unsigned) (types.enum [
+          "auto"
+          "auto-up"
+          "auto-down"
+          "auto-left"
+          "auto-right"
+          "auto-center-up"
+          "auto-center-down"
+          "auto-center-left"
+          "auto-center-right"
+        ]);
+        default = "auto";
+        description = ''
+          The position of the monitor as `{ x, y }` attributes,
+          or the name of some automatic behavior.
+
+          ::: {.note}
+          Coordinates are offsets relative to the top-left corner of virtual
+          screen space.
+          :::
+        '';
+      };
+      resolution = lib.mkOption {
+        type = types.either (point2DType types.ints.positive)
+          (types.enum [ "preferred" "highrr" "highres" "maxwidth" ]);
+        default = "preferred";
+        description = ''
+          The physical size of the display as `{ x, y }` attributes,
+          or the name of some automatic behavior.
+
+          ::: {.note}
+          If you want define your `position` attributes relative to
+          each other, use the value of {option}`scale` recursively.
+          :::
+        '';
+      };
+      scale = lib.mkOption {
+        type = types.either types.float (types.enum [ "auto" ]);
+        default = 1.0;
+        description = ''
+          The fractional scaling factor to use for Wayland-native programs.
+          The virtual size of the display will be each dimension divided by
+          this float. For example, the virtual size of a monitor with a physical
+          size of 2880x1800 pixels would be 1920x1200 virtual pixels.
+        '';
+      };
+      refreshRate = lib.mkOption {
+        type = types.nullOr (types.either types.ints.positive types.float);
+        default = null;
+        description = ''
+          The refresh rate of the monitor, if unspecified will choose
+          a default mode for your specified resolution.
+        '';
+      };
+      vrrMode = lib.mkOption {
+        inherit (vrrModeEnum) type apply;
+        default = null;
+        description = ''
+          Whether to enable variable refresh rate (FreeSync/AdaptiveSync/GSync).
+          This option is specifically for a monitor. There is a global option also,
+          `null`/`default` is for deferring.
+        '';
+      };
+      bitdepth = lib.mkOption {
+        type = types.enum [ 8 10 ];
+        default = 8;
+        description = ''
+          The color bit-depth of the monitor (8-bit or 10-bit color).
+        '';
+      };
+      transform = lib.mkOption {
+        inherit (transformEnum) type apply;
+        default = "Normal";
+        description = ''
+          Attribute names (enum identifiers) and values (repr) from the
+          following ~~enum~~ attribute set are accepted as variants
+          in this option `lib.types.enum`.
+
+          ```nix
+          ${lib.generators.toPretty { multiline = true; } transformEnum.mapping}
+          ```
+        '';
+      };
+      mirror = lib.mkOption {
+        type = types.nullOr types.singleLineStr;
+        default = null;
+        description = "The name of the monitor to mirror.";
+        example = lib.mdDoc ''
+          The "name" of the monitor is after the display protocol
+          it is connected with: `eDP-1`, `HDMI-A-1`, `DP-5`, `DP-6`, etc.
+        '';
+      };
+
+      size = lib.mkOption {
+        type = types.nullOr (point2DType types.float);
+        readOnly = true;
+        description = ''
+          The virtual display size after scaling,
+          intended for use in recursive Nix configurations.
+
+          This value can be `null` if {option}`resolution` is not an
+          attribute set of coordinates.
+        '';
+      };
+      keywordParams = lib.mkOption {
+        type = types.listOf types.singleLineStr;
+        internal = true;
+      };
+    };
+
+    config = let
+      positionIsPoint = (point2DType types.ints.unsigned).check config.position;
+      resolutionIsPoint =
+        (point2DType types.ints.positive).check config.resolution;
+    in {
+      name = lib.mkIf (config.description != null) "desc:${config.description}";
+
+      size = if resolutionIsPoint then
+        let
+          transform = transformEnum.variantName config.transform;
+          horizontal = {
+            x = config.resolution.x / config.scale;
+            y = config.resolution.y / config.scale;
+          };
+          vertical = {
+            x = horizontal.y;
+            y = horizontal.x;
+          };
+          lut = {
+            "Normal" = horizontal;
+            "Degrees90" = vertical;
+            "Degrees180" = horizontal;
+            "Degrees270" = vertical;
+            "Flipped" = horizontal;
+            "FlippedDegrees90" = vertical;
+            "FlippedDegrees180" = horizontal;
+            "FlippedDegrees270" = vertical;
+          };
+        in lut.${transform}
+      else
+        null;
+
+      keywordParams = lib.concatLists [
+        [
+          config.name
+        ]
+
+        # The resolution in `WIDTHxHEIGHT@REFRESH`, with `@REFRESH` optionally.
+        (lib.optional resolutionIsPoint
+          "${toString config.resolution.x}x${toString config.resolution.y}${
+            lib.optionalString (config.refreshRate != null)
+            "@${toString config.refreshRate}"
+          }")
+        # The resolution verbatim if it is an enum string.
+        (lib.optional (!resolutionIsPoint) config.resolution)
+
+        # The position in `XxY` format if it is a point.
+        (lib.optional positionIsPoint
+          "${toString config.position.x}x${toString config.position.y}")
+        # The position verbatim if it is an enum string.
+        (lib.optional (!positionIsPoint) config.position)
+
+        #
+        [ (toString config.scale) ]
+        [ "bitdepth" (toString config.bitdepth) ]
+        (lib.optionals (config.vrrMode != null) [
+          "vrr"
+          (toString config.vrrMode)
+        ])
+        [ "transform" (toString config.transform) ]
+        (lib.optionals (config.mirror != null) [ "mirror" config.mirror ])
+        #
+      ];
+    };
+  });
 in {
   options = {
     wayland.windowManager.hyprland.monitors = lib.mkOption {
-      type = types.attrsOf (types.submodule ({ config, ... }: {
-        options = {
-          name = lib.mkOption {
-            type = types.singleLineStr;
-            description = ''
-              The name of the monitor as shown in the output of
-              `hyprctl monitors`, for example `eDP-1` or `HDMI-A-1`.
-            '';
-          };
-          description = lib.mkOption {
-            type = types.nullOr types.singleLineStr;
-            default = null;
-            description = ''
-              The description of a monitor as shown in the output of
-              `hyprctl monitors` (without the parenthesized name at the end).
-            '';
-          };
-          position = lib.mkOption {
-            type = types.either (point2DType types.ints.unsigned) (types.enum [
-              "auto"
-              "auto-up"
-              "auto-down"
-              "auto-left"
-              "auto-right"
-              "auto-center-up"
-              "auto-center-down"
-              "auto-center-left"
-              "auto-center-right"
-            ]);
-            default = "auto";
-            description = ''
-              The position of the monitor as `{ x, y }` attributes,
-              or the name of some automatic behavior.
-
-              ::: {.note}
-              Coordinates are offsets relative to the top-left corner of virtual
-              screen space.
-              :::
-            '';
-          };
-          resolution = lib.mkOption {
-            type = types.either (point2DType types.ints.positive)
-              (types.enum [ "preferred" "highrr" "highres" "maxwidth" ]);
-            default = "preferred";
-            description = ''
-              The physical size of the display as `{ x, y }` attributes,
-              or the name of some automatic behavior.
-
-              ::: {.note}
-              If you want define your `position` attributes relative to
-              each other, use the value of {option}`scale` recursively.
-              :::
-            '';
-          };
-          scale = lib.mkOption {
-            type = types.either types.float (types.enum [ "auto" ]);
-            default = 1.0;
-            description = ''
-              The fractional scaling factor to use for Wayland-native programs.
-              The virtual size of the display will be each dimension divided by
-              this float. For example, the virtual size of a monitor with a physical
-              size of 2880x1800 pixels would be 1920x1200 virtual pixels.
-            '';
-          };
-          refreshRate = lib.mkOption {
-            type = types.nullOr (types.either types.ints.positive types.float);
-            default = null;
-            description = ''
-              The refresh rate of the monitor, if unspecified will choose
-              a default mode for your specified resolution.
-            '';
-          };
-          vrrMode = lib.mkOption {
-            inherit (vrrModeEnum) type apply;
-            default = null;
-            description = ''
-              Whether to enable variable refresh rate (FreeSync/AdaptiveSync/GSync).
-              This option is specifically for a monitor. There is a global option also,
-              `null`/`default` is for deferring.
-            '';
-          };
-          bitdepth = lib.mkOption {
-            type = types.enum [ 8 10 ];
-            default = 8;
-            description = ''
-              The color bit-depth of the monitor (8-bit or 10-bit color).
-            '';
-          };
-          transform = lib.mkOption {
-            inherit (transformEnum) type apply;
-            default = "Normal";
-            description = ''
-              Attribute names (enum identifiers) and values (repr) from the
-              following ~~enum~~ attribute set are accepted as variants
-              in this option `lib.types.enum`.
-
-              ```nix
-              ${lib.generators.toPretty { multiline = true; }
-              transformEnum.mapping}
-              ```
-            '';
-          };
-          mirror = lib.mkOption {
-            type = types.nullOr types.singleLineStr;
-            default = null;
-            description = "The name of the monitor to mirror.";
-            example = lib.mdDoc ''
-              The "name" of the monitor is after the display protocol
-              it is connected with: `eDP-1`, `HDMI-A-1`, `DP-5`, `DP-6`, etc.
-            '';
-          };
-
-          size = lib.mkOption {
-            type = types.nullOr (point2DType types.float);
-            readOnly = true;
-            description = ''
-              The virtual display size after scaling,
-              intended for use in recursive Nix configurations.
-
-              This value can be `null` if {option}`resolution` is not an
-              attribute set of coordinates.
-            '';
-          };
-          keywordParams = lib.mkOption {
-            type = types.listOf types.singleLineStr;
-            internal = true;
-          };
-        };
-
-        config = let
-          positionIsPoint =
-            (point2DType types.ints.unsigned).check config.position;
-          resolutionIsPoint =
-            (point2DType types.ints.positive).check config.resolution;
-        in {
-          name =
-            lib.mkIf (config.description != null) "desc:${config.description}";
-
-          size = if resolutionIsPoint then
-            let
-              transform = transformEnum.variantName config.transform;
-              horizontal = {
-                x = config.resolution.x / config.scale;
-                y = config.resolution.y / config.scale;
-              };
-              vertical = {
-                x = horizontal.y;
-                y = horizontal.x;
-              };
-              lut = {
-                "Normal" = horizontal;
-                "Degrees90" = vertical;
-                "Degrees180" = horizontal;
-                "Degrees270" = vertical;
-                "Flipped" = horizontal;
-                "FlippedDegrees90" = vertical;
-                "FlippedDegrees180" = horizontal;
-                "FlippedDegrees270" = vertical;
-              };
-            in lut.${transform}
-          else
-            null;
-
-          keywordParams = lib.concatLists [
-            [
-              config.name
-            ]
-
-            # The resolution in `WIDTHxHEIGHT@REFRESH`, with `@REFRESH` optionally.
-            (lib.optional resolutionIsPoint
-              "${toString config.resolution.x}x${toString config.resolution.y}${
-                lib.optionalString (config.refreshRate != null)
-                "@${toString config.refreshRate}"
-              }")
-            # The resolution verbatim if it is an enum string.
-            (lib.optional (!resolutionIsPoint) config.resolution)
-
-            # The position in `XxY` format if it is a point.
-            (lib.optional positionIsPoint
-              "${toString config.position.x}x${toString config.position.y}")
-            # The position verbatim if it is an enum string.
-            (lib.optional (!positionIsPoint) config.position)
-
-            #
-            [ (toString config.scale) ]
-            [ "bitdepth" (toString config.bitdepth) ]
-            (lib.optionals (config.vrrMode != null) [
-              "vrr"
-              (toString config.vrrMode)
-            ])
-            [ "transform" (toString config.transform) ]
-            (lib.optionals (config.mirror != null) [ "mirror" config.mirror ])
-            #
-          ];
-        };
-      }));
-
+      type = types.attrsOf monitorDefType;
+      default = { };
       description = ''
         Monitors to configure. The attribute name is not used in the
         Hyprland configuration, but is a convenience for recursive Nix.
@@ -266,7 +265,6 @@ in {
         is specified in the `name` attribute for the monitor.
         It is not the attribute name of the monitor in *this* parent set.
       '';
-
       example = lib.literalExpression ''
         (with config.wayland.windowManager.hyprland.monitors; {
           # The attribute name `internal` is for usage in recursive Nix.
@@ -278,8 +276,6 @@ in {
           };
         })
       '';
-
-      default = { };
     };
   };
 

--- a/hm-module/monitors.nix
+++ b/hm-module/monitors.nix
@@ -61,7 +61,12 @@ let
 
   monitorDefType = types.submodule ({ config, ... }: {
     # <https://github.com/NixOS/nixpkgs/issues/96006>
-    imports = [ (lib.mkRenamedOptionModule [ "name" ] [ "output" ]) ];
+    imports = [
+      (lib.mkRenamedOptionModule [ "name" ] [ "output" ])
+      # @Ujinn34 wanted this option to be named `disable`.
+      # <https://github.com/hyprwm/Hyprland/discussions/10848#discussioncomment-13583976>
+      (lib.mkRenamedOptionModule [ "disabled" ] [ "disable" ])
+    ];
 
     options = {
       output = lib.mkOption {
@@ -77,6 +82,13 @@ let
         description = ''
           The description of a monitor as shown in the output of
           `hyprctl monitors` (without the parenthesized name at the end).
+        '';
+      };
+      disable = lib.mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Disable this monitor, removing it from the layout.
         '';
       };
       position = lib.mkOption {
@@ -278,6 +290,7 @@ in {
     wayland.windowManager.hyprland.config.monitorv2 = lib.mapAttrsToList
       (_: def: {
         inherit (def) output;
+        disabled = lib.mkIf def.disable def.disable;
         mode = def.modeString;
         position = def.positionString;
         scale = lib.mkIf (def.scale != 1.0) def.scale;

--- a/hm-module/monitors.nix
+++ b/hm-module/monitors.nix
@@ -186,6 +186,11 @@ let
         readOnly = true;
         internal = true;
       };
+      positionString = lib.mkOption {
+        type = types.singleLineStr;
+        readOnly = true;
+        internal = true;
+      };
       keywordParams = lib.mkOption {
         type = types.listOf types.singleLineStr;
         internal = true;
@@ -234,17 +239,19 @@ let
       # The resolution verbatim if it is an enum string.
         config.resolution;
 
+      positionString = if positionIsPoint then
+      # The position in `XxY` format if it is a point.
+        "${toString config.position.x}x${toString config.position.y}"
+      else
+      # The position verbatim if it is an enum string.
+        config.position;
+
       keywordParams = lib.concatLists [
         [
           config.name
           config.modeString
+          config.positionString
         ]
-
-        # The position in `XxY` format if it is a point.
-        (lib.optional positionIsPoint
-          "${toString config.position.x}x${toString config.position.y}")
-        # The position verbatim if it is an enum string.
-        (lib.optional (!positionIsPoint) config.position)
 
         #
         [ (toString config.scale) ]

--- a/hm-module/monitors.nix
+++ b/hm-module/monitors.nix
@@ -181,6 +181,11 @@ let
           attribute set of coordinates.
         '';
       };
+      modeString = lib.mkOption {
+        type = types.singleLineStr;
+        readOnly = true;
+        internal = true;
+      };
       keywordParams = lib.mkOption {
         type = types.listOf types.singleLineStr;
         internal = true;
@@ -219,19 +224,21 @@ let
       else
         null;
 
+      modeString = if resolutionIsPoint then
+      # The resolution in `WIDTHxHEIGHT@REFRESH`, with `@REFRESH` optionally.
+        "${toString config.resolution.x}x${toString config.resolution.y}${
+          lib.optionalString (config.refreshRate != null)
+          "@${toString config.refreshRate}"
+        }"
+      else
+      # The resolution verbatim if it is an enum string.
+        config.resolution;
+
       keywordParams = lib.concatLists [
         [
           config.name
+          config.modeString
         ]
-
-        # The resolution in `WIDTHxHEIGHT@REFRESH`, with `@REFRESH` optionally.
-        (lib.optional resolutionIsPoint
-          "${toString config.resolution.x}x${toString config.resolution.y}${
-            lib.optionalString (config.refreshRate != null)
-            "@${toString config.refreshRate}"
-          }")
-        # The resolution verbatim if it is an enum string.
-        (lib.optional (!resolutionIsPoint) config.resolution)
 
         # The position in `XxY` format if it is a point.
         (lib.optional positionIsPoint

--- a/hm-module/monitors.nix
+++ b/hm-module/monitors.nix
@@ -60,12 +60,15 @@ let
     };
 
   monitorDefType = types.submodule ({ config, ... }: {
+    # <https://github.com/NixOS/nixpkgs/issues/96006>
+    imports = [ (lib.mkRenamedOptionModule [ "name" ] [ "output" ]) ];
+
     options = {
-      name = lib.mkOption {
+      output = lib.mkOption {
         type = types.singleLineStr;
         description = ''
-          The name of the monitor as shown in the output of
-          `hyprctl monitors`, for example `eDP-1` or `HDMI-A-1`.
+          The name of the output node that the monitor is connected to,
+          as shown in the output of `hyprctl monitors`, for example `eDP-1` or `HDMI-A-1`.
         '';
       };
       description = lib.mkOption {
@@ -163,10 +166,10 @@ let
       mirror = lib.mkOption {
         type = types.nullOr types.singleLineStr;
         default = null;
-        description = "The name of the monitor to mirror.";
+        description = "The output name of the monitor to mirror.";
         example = lib.mdDoc ''
-          The "name" of the monitor is after the display protocol
-          it is connected with: `eDP-1`, `HDMI-A-1`, `DP-5`, `DP-6`, etc.
+          The "output" of the monitor is named after its DRM output node,
+          usually the connector, for example: `eDP-1`, `HDMI-A-1`, `DP-5`, `DP-6`.
         '';
       };
 
@@ -202,7 +205,8 @@ let
       resolutionIsPoint =
         (point2DType types.ints.positive).check config.resolution;
     in {
-      name = lib.mkIf (config.description != null) "desc:${config.description}";
+      output =
+        lib.mkIf (config.description != null) "desc:${config.description}";
 
       size = if resolutionIsPoint then
         let
@@ -248,7 +252,7 @@ let
 
       keywordParams = lib.concatLists [
         [
-          config.name
+          config.output
           config.modeString
           config.positionString
         ]
@@ -275,15 +279,15 @@ in {
         Monitors to configure. The attribute name is not used in the
         Hyprland configuration, but is a convenience for recursive Nix.
 
-        The "name" the monitor will have (the connector, not make and model)
-        is specified in the `name` attribute for the monitor.
+        The "output" the monitor will have (the connector, not make and model)
+        is specified in the `output` attribute for the monitor.
         It is not the attribute name of the monitor in *this* parent set.
       '';
       example = lib.literalExpression ''
         (with config.wayland.windowManager.hyprland.monitors; {
           # The attribute name `internal` is for usage in recursive Nix.
           internal = {
-            name = "eDP-1";
+            output = "eDP-1";
             pos = "auto"; # `auto` is default
             size = "preferred"; # `preferred` is default
             bitdepth = 10;

--- a/hm-module/monitors.nix
+++ b/hm-module/monitors.nix
@@ -194,10 +194,6 @@ let
         readOnly = true;
         internal = true;
       };
-      keywordParams = lib.mkOption {
-        type = types.listOf types.singleLineStr;
-        internal = true;
-      };
     };
 
     config = let
@@ -249,25 +245,6 @@ let
       else
       # The position verbatim if it is an enum string.
         config.position;
-
-      keywordParams = lib.concatLists [
-        [
-          config.output
-          config.modeString
-          config.positionString
-        ]
-
-        #
-        [ (toString config.scale) ]
-        [ "bitdepth" (toString config.bitdepth) ]
-        (lib.optionals (config.vrrMode != null) [
-          "vrr"
-          (toString config.vrrMode)
-        ])
-        [ "transform" (toString config.transform) ]
-        (lib.optionals (config.mirror != null) [ "mirror" config.mirror ])
-        #
-      ];
     };
   });
 in {
@@ -298,7 +275,17 @@ in {
   };
 
   config = {
-    wayland.windowManager.hyprland.config.monitor = lib.mapAttrsToList
-      (attrName: monitor: lib.concatStringsSep "," monitor.keywordParams) cfg;
+    wayland.windowManager.hyprland.config.monitorv2 = lib.mapAttrsToList
+      (_: def: {
+        inherit (def) output;
+        mode = def.modeString;
+        position = def.positionString;
+        scale = lib.mkIf (def.scale != 1.0) def.scale;
+        vrr = lib.mkIf (def.vrrMode != null) def.vrrMode;
+        bitdepth = lib.mkIf (def.bitdepth != 8) def.bitdepth;
+        transform = let default = transformEnum.mapping."Normal";
+        in lib.mkIf (def.transform != default) def.transform;
+        mirror = lib.mkIf (def.mirror != null) def.mirror;
+      }) cfg;
   };
 }


### PR DESCRIPTION
This change replaces the `monitor =` keyword parameters syntax with a `monitorv2 { }` "special category".

You can run the following commands to see what the generated configuration looks like:
```
nix build path:.#checks.x86_64-linux.example-vertical-monitors
cat result/hyprland.conf
```

<details>
<summary>Output excerpt</summary>

```ini
monitorv2 {
    output =
    mode = preferred
    position = 2680x1440
}

monitorv2 {
    output = desc:ASUSTek COMPUTER INC ASUS VG34V S8LMTF062111
    mode = 3440x1440@165
    position = 0x0
}

monitorv2 {
    output = desc:Samsung Display Corp. 0x4193
    mode = 2880x1800@90
    position = 760x1440
    scale = 1.500000
    bitdepth = 10
}
```

</details>

### Note to reviewers:

I highly recommend reviewing the individual commits for this PR, because the first commit (`hm-mod: monitors: extract monitorDefType`) is very noisy, and will make the "Files changed" rather incomprehensible.

Note that this PR changes the output syntax, but does not reach parity quite yet. There's still more work to do, I'll be tracking that in #6. As of this change, only one new option has been introduced: `disable`.