### PR TITLE
examples: add vertical-monitors example

### DIFF
--- a/examples/default.nix
+++ b/examples/default.nix
@@ -43,4 +43,9 @@ in {
   # This example has an empty module (`{ }`) because it is only intended to
   # check the generation of a minimal/default configuration.
   hyprland-enable = (mkExampleHome system { }).activationPackage;
+
+  # For debugging purposes,
+  # `nix build path:.#checks.x86_64-linux.example-vertical-monitors` may be of use.
+  vertical-monitors = (mkExampleHome system ./vertical-monitors.nix) # #
+    .config.wayland.windowManager.hyprland.configFile."hyprland.conf".source;
 }

--- a/examples/vertical-monitors.nix
+++ b/examples/vertical-monitors.nix
@@ -1,0 +1,77 @@
+# This example shows how to configure the size and position of vertically
+# stacked monitors, taken from @spikespaz' personal configuration.
+{ lib, config, ... }: {
+  wayland.windowManager.hyprland.monitors =
+    with config.wayland.windowManager.hyprland.monitors; {
+      # This display is always present, since it's built in to the laptop.
+      laptop-internal = {
+        # Either `name` or `description` must be defined.
+        #
+        # You should probably prefer `description` because for most DRM output
+        # nodes (for example `HDMI-A-1` or `DP-5`), hard-coded settings aren't
+        # necessarily correct for any arbitrary monitor attached to that output.
+        #
+        # Your system probably also makes no guarantee that the name of the
+        # DRM node is consistent between reboots or re-connections.
+        #
+        # Since this display is built-in, in this specific circumstance,
+        # using `name = "eDP-1"` would also work fine.
+        description = "Samsung Display Corp. 0x4193";
+        resolution = {
+          x = 2880;
+          y = 1800;
+        };
+        # When positioning monitors, `size` is provided as a convenience.
+        # For `laptop-internal`, it will be `{ x = 1920; y = 1200; }`
+        # (that's `{ x = resolution.x / scale; y = resolution.y / scale; }`).
+        scale = 1.5;
+        refreshRate = 90;
+        # The position of this monitor is calculated, taking into account its
+        # own scaled size, and the scaled width and height of other monitors.
+        #
+        # The virtual `size` is not intended to be set explicitly.
+        #
+        # If the `transform` option causes a monitor to be rotated, the
+        # `x` and `y` coordinates of `size` will be swapped for you.
+        position = lib.mapAttrs (_: builtins.floor) {
+          # Offset to be horizontally centered relative to `desktop-ultrawide`.
+          x = desktop-ultrawide.position.x
+            + (desktop-ultrawide.size.x - laptop-internal.size.x) / 2;
+          # Vertically shifted down according to the position and scaled height
+          # of `desktop-ultrawide`.
+          y = desktop-ultrawide.position.y + desktop-ultrawide.size.y;
+        };
+        bitdepth = 10;
+      };
+      # This display is positioned above and center relative to
+      # `laptop-internal`, in a vertical stack configuration.
+      desktop-ultrawide = {
+        description = "ASUSTek COMPUTER INC ASUS VG34V S8LMTF062111";
+        resolution = {
+          x = 3440;
+          y = 1440;
+        };
+        refreshRate = 165;
+        # This monitor's position (top-left corner) is at the origin point
+        # of virtual screen space (also top-left corner).
+        # The widest and top-most monitor gets the honor of being positioned
+        # at the origin, because while negative coordinates are supported by
+        # Hyprland, some popups and tooltips (specifically Qt) don't render
+        # correctly if they're in a different quadrant from other monitors.
+        position = {
+          x = 0;
+          y = 0;
+        };
+      };
+      # Here is an entry that will handle arbitrary monitors,
+      # setting the position to the right side of `laptop-internal`.
+      default = {
+        name = "";
+        resolution = "preferred";
+        position = lib.mapAttrs (_: builtins.floor) {
+          x = laptop-internal.position.x + laptop-internal.size.x;
+          y = laptop-internal.position.y;
+        };
+      };
+    };
+}


### PR DESCRIPTION
I'm committing this ahead of `monitorv2` work because I'm using it as a reference across multiple branches, so I want it in the `master` source tree.

This example can be built with:
```
nix build path:.#checks.x86_64-linux.example-vertical-monitors
```
Then you may inspect the generated configuration:
```
cat result/hyprland.conf
```
<details>
<summary>
Output
</summary>

```ini
env = NIXOS_OZONE_WL,1

exec-once = /nix/store/lww2khz04qsc8prjp8l0haldwz15yivi-dbus-1.14.10/bin/dbus-update-activation-environment DISPLAY WAYLAND_DISPLAY HYPRLAND_INSTANCE_SIGNATURE XDG_CURRENT_DESKTOP
exec-once = /nix/store/lww2khz04qsc8prjp8l0haldwz15yivi-dbus-1.14.10/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY HYPRLAND_INSTANCE_SIGNATURE XDG_CURRENT_DESKTOP
exec-once = systemctl --user stop hyprland-session.target
exec-once = systemctl --user start hyprland-session.target

source = /home/example/.config/hypr/devices.conf
source = /home/example/.config/hypr/keybinds.conf

monitor = ,preferred,2680x1440,1.000000,bitdepth,8,transform,0
monitor = desc:ASUSTek COMPUTER INC ASUS VG34V S8LMTF062111,3440x1440@165,0x0,1.000000,bitdepth,8,transform,0
monitor = desc:Samsung Display Corp. 0x4193,2880x1800@90,760x1440,1.500000,bitdepth,10,transform,0

animations {
    bezier = easeInBack, 0.360000, 0, 0.660000, -0.560000
    bezier = easeInCirc, 0.550000, 0, 1, 0.450000
    bezier = easeInCubic, 0.320000, 0, 0.670000, 0
    bezier = easeInExpo, 0.700000, 0, 0.840000, 0
    bezier = easeInOutBack, 0.680000, -0.600000, 0.320000, 1.600000
    bezier = easeInOutCirc, 0.850000, 0, 0.150000, 1
    bezier = easeInOutCubic, 0.650000, 0, 0.350000, 1
    bezier = easeInOutExpo, 0.870000, 0, 0.130000, 1
    bezier = easeInOutQuad, 0.450000, 0, 0.550000, 1
    bezier = easeInOutQuart, 0.760000, 0, 0.240000, 1
    bezier = easeInOutQuint, 0.830000, 0, 0.170000, 1
    bezier = easeInOutSine, 0.370000, 0, 0.630000, 1
    bezier = easeInQuad, 0.110000, 0, 0.500000, 0
    bezier = easeInQuart, 0.500000, 0, 0.750000, 0
    bezier = easeInQuint, 0.640000, 0, 0.780000, 0
    bezier = easeInSine, 0.120000, 0, 0.390000, 0
    bezier = easeOutBack, 0.340000, 1.560000, 0.640000, 1
    bezier = easeOutCirc, 0, 0.550000, 0.450000, 1
    bezier = easeOutCubic, 0.330000, 1, 0.680000, 1
    bezier = easeOutExpo, 0.160000, 1, 0.300000, 1
    bezier = easeOutQuad, 0.500000, 1, 0.890000, 1
    bezier = easeOutQuart, 0.250000, 1, 0.500000, 1
    bezier = easeOutQuint, 0.220000, 1, 0.360000, 1
    bezier = easeOutSine, 0.610000, 1, 0.880000, 1
    bezier = linear, 0, 0, 1, 1
}

misc {
    disable_autoreload = true
}
```

</details>