### PR TITLE
hm-mod: use importApply for module parts

### DIFF
--- a/hm-module/default.nix
+++ b/hm-module/default.nix
@@ -7,7 +7,7 @@ in {
     "services/window-managers/hyprland.nix"
   ];
 
-  imports = map (nix: import nix { inherit self lib; }) [
+  imports = map (nix: lib.modules.importApply nix { inherit self lib; }) [
     ./config.nix
     ./compat.nix
     ./events.nix


### PR DESCRIPTION
The function `importApply` replaces manual imports for partial modules. This is evidently the intended mechanism for passing an extra positional to the file's function. It will internally call `lib.setDefaultModuleLocation` to allow for better error messages.